### PR TITLE
Add OwningHandle::{update, try_update} to allow modifying the stored value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -441,6 +441,24 @@ impl<O, H> OwningHandle<O, H>
           _owner: o,
         })
     }
+
+    /// Update the value inside the OwningHandle. The provided callback will be
+    /// invoked with a pointer to the object owned by the `o` originally
+    /// provided upon construction, and a mutable reference to the value that
+    /// was returned by the construction callback.
+    pub fn update<F>(&mut self, f: F)
+        where F: Fn(*const O::Target, &mut H)
+    {
+        f(self._owner.deref() as *const O::Target, &mut self.handle);
+    }
+
+    /// Like `update`, except fallible.  Note that any modifications made to the
+    /// value will persist even if the callback returns an `Err`.
+    pub fn try_update<F, E>(&mut self, f: F) -> Result<(), E>
+        where F: Fn(*const O::Target, &mut H) -> Result<(), E>
+    {
+        f(self._owner.deref() as *const O::Target, &mut self.handle)
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I have an `OwningHandle` where the value type contains a number of expensive-to-compute objects within it (as `Option`s).  They are computed from the owned value.  Upon construction I want them all to be `None`, and I will lazily compute them when needed.  `deref_mut` is not sufficient for this because it doesn't allow me to access the owned value again.