### PR TITLE
impl StableAddress for OwningRefMut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -898,6 +898,8 @@ impl<O, T: ?Sized> DerefMut for OwningRefMut<O, T> {
 
 unsafe impl<O, T: ?Sized> StableAddress for OwningRef<O, T> {}
 
+unsafe impl<O, T: ?Sized> StableAddress for OwningRefMut<O, T> {}
+
 impl<O, T: ?Sized> AsRef<T> for OwningRef<O, T> {
     fn as_ref(&self) -> &T {
         &*self


### PR DESCRIPTION
That `OwningRefMut` does not impl `StableAddress` seems a bit of an oversight.