### PR TITLE
Add OwningHandle::map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "owning_ref"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Marvin Löbel <loebel.marvin@gmail.com>"]
 license = "MIT"
 


### PR DESCRIPTION
This can be used to convert a RAII guard, for example. In my use-case I'm downgrading a Write guard to a Read guard.

AFAIK this doesn't need to be unsafe as it can rely on the safety of the previously built handle.