### PR TITLE
Add support for async functions to OwningHandle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "owning_ref"
 version = "0.4.1"
 authors = ["Marvin Löbel <loebel.marvin@gmail.com>"]
 license = "MIT"
+edition = "2018"
 
 description = "A library for creating references that carry their owner with them."
 readme = "README.md"
@@ -11,5 +12,11 @@ documentation = "http://kimundi.github.io/owning-ref-rs/owning_ref/index.html"
 repository = "https://github.com/Kimundi/owning-ref-rs"
 keywords = ["reference", "sibling", "field", "owning"]
 
+[features]
+async = []
+
 [dependencies]
 stable_deref_trait = "1.0.0"
+
+[dev-dependencies]
+tokio = { version = "0.2.22", features = ["macros", "rt-threaded", "time"] }


### PR DESCRIPTION
Adds `new_with_async_fn` and `try_new_async` static functions to OwningHandle to support handle creation by async functions.
These are gated behind a new `async` feature.

Note that [async closures](https://github.com/rust-lang/rust/issues/62290) are currently unstable, so unlike their synchronous counterparts these functions will have to be passed a regular function in stable rust.

Closes:  #67
