### PR TITLE
Add rustfmt.toml and run rustfmt.

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+edition = "2018"
+format_code_in_doc_comments = true
+imports_granularity = "Crate"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,9 @@ fn main() {
 */
 
 extern crate stable_deref_trait;
-pub use stable_deref_trait::{StableDeref as StableAddress, CloneStableDeref as CloneStableAddress};
+pub use stable_deref_trait::{
+    CloneStableDeref as CloneStableAddress, StableDeref as StableAddress,
+};
 
 /// An owning reference.
 ///
@@ -309,8 +311,9 @@ impl<O, T: ?Sized> OwningRef<O, T> {
     /// }
     /// ```
     pub fn new(o: O) -> Self
-        where O: StableAddress,
-              O: Deref<Target = T>,
+    where
+        O: StableAddress,
+        O: Deref<Target = T>,
     {
         OwningRef {
             reference: &*o,
@@ -324,7 +327,8 @@ impl<O, T: ?Sized> OwningRef<O, T> {
     /// This is useful for cases where coherence rules prevents implementing the trait
     /// without adding a dependency to this crate in a third-party library.
     pub unsafe fn new_assert_stable_address(o: O) -> Self
-        where O: Deref<Target = T>,
+    where
+        O: Deref<Target = T>,
     {
         OwningRef {
             reference: &*o,
@@ -353,8 +357,9 @@ impl<O, T: ?Sized> OwningRef<O, T> {
     /// }
     /// ```
     pub fn map<F, U: ?Sized>(self, f: F) -> OwningRef<O, U>
-        where O: StableAddress,
-              F: FnOnce(&T) -> &U
+    where
+        O: StableAddress,
+        F: FnOnce(&T) -> &U,
     {
         OwningRef {
             reference: f(&self),
@@ -385,8 +390,9 @@ impl<O, T: ?Sized> OwningRef<O, T> {
     /// }
     /// ```
     pub fn map_with_owner<F, U: ?Sized>(self, f: F) -> OwningRef<O, U>
-        where O: StableAddress,
-              F: for<'a> FnOnce(&'a O, &'a T) -> &'a U
+    where
+        O: StableAddress,
+        F: for<'a> FnOnce(&'a O, &'a T) -> &'a U,
     {
         OwningRef {
             reference: f(&self.owner, &self),
@@ -410,9 +416,7 @@ impl<O, T: ?Sized> OwningRef<O, T> {
     ///
     ///     // create a owning reference that points at the
     ///     // third element of the array.
-    ///     let owning_ref = owning_ref.filter_map(|array| {
-    ///         (array[2] == 3).then(|| &array[2])
-    ///     });
+    ///     let owning_ref = owning_ref.filter_map(|array| (array[2] == 3).then(|| &array[2]));
     ///     assert_eq!(*owning_ref.unwrap(), 3);
     /// }
     /// ```
@@ -444,9 +448,8 @@ impl<O, T: ?Sized> OwningRef<O, T> {
     ///
     ///     // create a owning reference that points at the
     ///     // second element of the array from the owning ref that was pointing to the third
-    ///     let owning_ref = owning_ref.filter_map_with_owner(|array, _prev| {
-    ///         (array[1] == 2).then(|| &array[1])
-    ///     });
+    ///     let owning_ref =
+    ///         owning_ref.filter_map_with_owner(|array, _prev| (array[1] == 2).then(|| &array[1]));
     ///     assert_eq!(*owning_ref.unwrap(), 2);
     /// }
     /// ```
@@ -478,14 +481,19 @@ impl<O, T: ?Sized> OwningRef<O, T> {
     ///     // create a owning reference that points at the
     ///     // third element of the array.
     ///     let owning_ref = owning_ref.try_map(|array| {
-    ///         if array[2] == 3 { Ok(&array[2]) } else { Err(()) }
+    ///         if array[2] == 3 {
+    ///             Ok(&array[2])
+    ///         } else {
+    ///             Err(())
+    ///         }
     ///     });
     ///     assert_eq!(*owning_ref.unwrap(), 3);
     /// }
     /// ```
     pub fn try_map<F, U: ?Sized, E>(self, f: F) -> Result<OwningRef<O, U>, E>
-        where O: StableAddress,
-              F: FnOnce(&T) -> Result<&U, E>
+    where
+        O: StableAddress,
+        F: FnOnce(&T) -> Result<&U, E>,
     {
         Ok(OwningRef {
             reference: f(&self)?,
@@ -511,14 +519,19 @@ impl<O, T: ?Sized> OwningRef<O, T> {
     ///     // create a owning reference that points at the
     ///     // second element of the array from the owning ref that was pointing to the third
     ///     let owning_ref = owning_ref.try_map_with_owner(|array, _prev| {
-    ///         if array[1] == 2 { Ok(&array[1]) } else { Err(()) }
+    ///         if array[1] == 2 {
+    ///             Ok(&array[1])
+    ///         } else {
+    ///             Err(())
+    ///         }
     ///     });
     ///     assert_eq!(*owning_ref.unwrap(), 2);
     /// }
     /// ```
     pub fn try_map_with_owner<F, U: ?Sized, E>(self, f: F) -> Result<OwningRef<O, U>, E>
-        where O: StableAddress,
-              F: for<'a> FnOnce(&'a O, &'a T) -> Result<&'a U, E>
+    where
+        O: StableAddress,
+        F: for<'a> FnOnce(&'a O, &'a T) -> Result<&'a U, E>,
     {
         Ok(OwningRef {
             reference: f(&self.owner, &self)?,
@@ -532,9 +545,10 @@ impl<O, T: ?Sized> OwningRef<O, T> {
     /// so that the reference into it remains valid. This function is marked unsafe
     /// because the user needs to manually uphold this guarantee.
     pub unsafe fn map_owner<F, P>(self, f: F) -> OwningRef<P, T>
-        where O: StableAddress,
-              P: StableAddress,
-              F: FnOnce(O) -> P
+    where
+        O: StableAddress,
+        P: StableAddress,
+        F: FnOnce(O) -> P,
     {
         OwningRef {
             reference: self.reference,
@@ -561,33 +575,32 @@ impl<O, T: ?Sized> OwningRef<O, T> {
     /// # Example
     /// ```
     /// extern crate owning_ref;
-    /// use owning_ref::{OwningRef, Erased};
+    /// use owning_ref::{Erased, OwningRef};
     ///
     /// fn main() {
     ///     // NB: Using the concrete types here for explicitnes.
     ///     // For less verbose code type aliases like `BoxRef` are provided.
     ///
-    ///     let owning_ref_a: OwningRef<Box<[i32; 4]>, [i32; 4]>
-    ///         = OwningRef::new(Box::new([1, 2, 3, 4]));
+    ///     let owning_ref_a: OwningRef<Box<[i32; 4]>, [i32; 4]> =
+    ///         OwningRef::new(Box::new([1, 2, 3, 4]));
     ///
-    ///     let owning_ref_b: OwningRef<Box<Vec<(i32, bool)>>, Vec<(i32, bool)>>
-    ///         = OwningRef::new(Box::new(vec![(0, false), (1, true)]));
+    ///     let owning_ref_b: OwningRef<Box<Vec<(i32, bool)>>, Vec<(i32, bool)>> =
+    ///         OwningRef::new(Box::new(vec![(0, false), (1, true)]));
     ///
-    ///     let owning_ref_a: OwningRef<Box<[i32; 4]>, i32>
-    ///         = owning_ref_a.map(|a| &a[0]);
+    ///     let owning_ref_a: OwningRef<Box<[i32; 4]>, i32> = owning_ref_a.map(|a| &a[0]);
     ///
-    ///     let owning_ref_b: OwningRef<Box<Vec<(i32, bool)>>, i32>
-    ///         = owning_ref_b.map(|a| &a[1].0);
+    ///     let owning_ref_b: OwningRef<Box<Vec<(i32, bool)>>, i32> = owning_ref_b.map(|a| &a[1].0);
     ///
-    ///     let owning_refs: [OwningRef<Box<dyn Erased>, i32>; 2]
-    ///         = [owning_ref_a.erase_owner(), owning_ref_b.erase_owner()];
+    ///     let owning_refs: [OwningRef<Box<dyn Erased>, i32>; 2] =
+    ///         [owning_ref_a.erase_owner(), owning_ref_b.erase_owner()];
     ///
     ///     assert_eq!(*owning_refs[0], 1);
     ///     assert_eq!(*owning_refs[1], 1);
     /// }
     /// ```
     pub fn erase_owner<'a>(self) -> OwningRef<O::Erased, T>
-        where O: IntoErased<'a>,
+    where
+        O: IntoErased<'a>,
     {
         OwningRef {
             reference: self.reference,
@@ -623,8 +636,9 @@ impl<O, T: ?Sized> OwningRefMut<O, T> {
     /// }
     /// ```
     pub fn new(mut o: O) -> Self
-        where O: StableAddress,
-              O: DerefMut<Target = T>,
+    where
+        O: StableAddress,
+        O: DerefMut<Target = T>,
     {
         OwningRefMut {
             reference: &mut *o,
@@ -638,7 +652,8 @@ impl<O, T: ?Sized> OwningRefMut<O, T> {
     /// This is useful for cases where coherence rules prevents implementing the trait
     /// without adding a dependency to this crate in a third-party library.
     pub unsafe fn new_assert_stable_address(mut o: O) -> Self
-        where O: DerefMut<Target = T>,
+    where
+        O: DerefMut<Target = T>,
     {
         OwningRefMut {
             reference: &mut *o,
@@ -667,8 +682,9 @@ impl<O, T: ?Sized> OwningRefMut<O, T> {
     /// }
     /// ```
     pub fn map<F, U: ?Sized>(mut self, f: F) -> OwningRef<O, U>
-        where O: StableAddress,
-              F: FnOnce(&mut T) -> &U
+    where
+        O: StableAddress,
+        F: FnOnce(&mut T) -> &U,
     {
         OwningRef {
             reference: f(&mut self),
@@ -697,8 +713,9 @@ impl<O, T: ?Sized> OwningRefMut<O, T> {
     /// }
     /// ```
     pub fn map_mut<F, U: ?Sized>(mut self, f: F) -> OwningRefMut<O, U>
-        where O: StableAddress,
-              F: FnOnce(&mut T) -> &mut U
+    where
+        O: StableAddress,
+        F: FnOnce(&mut T) -> &mut U,
     {
         OwningRefMut {
             reference: f(&mut self),
@@ -723,14 +740,19 @@ impl<O, T: ?Sized> OwningRefMut<O, T> {
     ///     // create a owning reference that points at the
     ///     // third element of the array.
     ///     let owning_ref = owning_ref_mut.try_map(|array| {
-    ///         if array[2] == 3 { Ok(&array[2]) } else { Err(()) }
+    ///         if array[2] == 3 {
+    ///             Ok(&array[2])
+    ///         } else {
+    ///             Err(())
+    ///         }
     ///     });
     ///     assert_eq!(*owning_ref.unwrap(), 3);
     /// }
     /// ```
     pub fn try_map<F, U: ?Sized, E>(mut self, f: F) -> Result<OwningRef<O, U>, E>
-        where O: StableAddress,
-              F: FnOnce(&mut T) -> Result<&U, E>
+    where
+        O: StableAddress,
+        F: FnOnce(&mut T) -> Result<&U, E>,
     {
         Ok(OwningRef {
             reference: f(&mut self)?,
@@ -755,14 +777,19 @@ impl<O, T: ?Sized> OwningRefMut<O, T> {
     ///     // create a owning reference that points at the
     ///     // third element of the array.
     ///     let owning_ref_mut = owning_ref_mut.try_map_mut(|array| {
-    ///         if array[2] == 3 { Ok(&mut array[2]) } else { Err(()) }
+    ///         if array[2] == 3 {
+    ///             Ok(&mut array[2])
+    ///         } else {
+    ///             Err(())
+    ///         }
     ///     });
     ///     assert_eq!(*owning_ref_mut.unwrap(), 3);
     /// }
     /// ```
     pub fn try_map_mut<F, U: ?Sized, E>(mut self, f: F) -> Result<OwningRefMut<O, U>, E>
-        where O: StableAddress,
-              F: FnOnce(&mut T) -> Result<&mut U, E>
+    where
+        O: StableAddress,
+        F: FnOnce(&mut T) -> Result<&mut U, E>,
     {
         Ok(OwningRefMut {
             reference: f(&mut self)?,
@@ -776,9 +803,10 @@ impl<O, T: ?Sized> OwningRefMut<O, T> {
     /// so that the reference into it remains valid. This function is marked unsafe
     /// because the user needs to manually uphold this guarantee.
     pub unsafe fn map_owner<F, P>(self, f: F) -> OwningRefMut<P, T>
-        where O: StableAddress,
-              P: StableAddress,
-              F: FnOnce(O) -> P
+    where
+        O: StableAddress,
+        P: StableAddress,
+        F: FnOnce(O) -> P,
     {
         OwningRefMut {
             reference: self.reference,
@@ -805,33 +833,36 @@ impl<O, T: ?Sized> OwningRefMut<O, T> {
     /// # Example
     /// ```
     /// extern crate owning_ref;
-    /// use owning_ref::{OwningRefMut, Erased};
+    /// use owning_ref::{Erased, OwningRefMut};
     ///
     /// fn main() {
     ///     // NB: Using the concrete types here for explicitnes.
     ///     // For less verbose code type aliases like `BoxRef` are provided.
     ///
-    ///     let owning_ref_mut_a: OwningRefMut<Box<[i32; 4]>, [i32; 4]>
-    ///         = OwningRefMut::new(Box::new([1, 2, 3, 4]));
+    ///     let owning_ref_mut_a: OwningRefMut<Box<[i32; 4]>, [i32; 4]> =
+    ///         OwningRefMut::new(Box::new([1, 2, 3, 4]));
     ///
-    ///     let owning_ref_mut_b: OwningRefMut<Box<Vec<(i32, bool)>>, Vec<(i32, bool)>>
-    ///         = OwningRefMut::new(Box::new(vec![(0, false), (1, true)]));
+    ///     let owning_ref_mut_b: OwningRefMut<Box<Vec<(i32, bool)>>, Vec<(i32, bool)>> =
+    ///         OwningRefMut::new(Box::new(vec![(0, false), (1, true)]));
     ///
-    ///     let owning_ref_mut_a: OwningRefMut<Box<[i32; 4]>, i32>
-    ///         = owning_ref_mut_a.map_mut(|a| &mut a[0]);
+    ///     let owning_ref_mut_a: OwningRefMut<Box<[i32; 4]>, i32> =
+    ///         owning_ref_mut_a.map_mut(|a| &mut a[0]);
     ///
-    ///     let owning_ref_mut_b: OwningRefMut<Box<Vec<(i32, bool)>>, i32>
-    ///         = owning_ref_mut_b.map_mut(|a| &mut a[1].0);
+    ///     let owning_ref_mut_b: OwningRefMut<Box<Vec<(i32, bool)>>, i32> =
+    ///         owning_ref_mut_b.map_mut(|a| &mut a[1].0);
     ///
-    ///     let owning_refs_mut: [OwningRefMut<Box<dyn Erased>, i32>; 2]
-    ///         = [owning_ref_mut_a.erase_owner(), owning_ref_mut_b.erase_owner()];
+    ///     let owning_refs_mut: [OwningRefMut<Box<dyn Erased>, i32>; 2] = [
+    ///         owning_ref_mut_a.erase_owner(),
+    ///         owning_ref_mut_b.erase_owner(),
+    ///     ];
     ///
     ///     assert_eq!(*owning_refs_mut[0], 1);
     ///     assert_eq!(*owning_refs_mut[1], 1);
     /// }
     /// ```
     pub fn erase_owner<'a>(self) -> OwningRefMut<O::Erased, T>
-        where O: IntoErased<'a>,
+    where
+        O: IntoErased<'a>,
     {
         OwningRefMut {
             reference: self.reference,
@@ -883,14 +914,18 @@ use std::ops::{Deref, DerefMut};
 /// implemented for common data structures. Types that implement `ToHandle` can
 /// be wrapped into an `OwningHandle` without passing a callback.
 pub struct OwningHandle<O, H>
-    where O: StableAddress, H: Deref,
+where
+    O: StableAddress,
+    H: Deref,
 {
     handle: H,
     _owner: O,
 }
 
 impl<O, H> Deref for OwningHandle<O, H>
-    where O: StableAddress, H: Deref,
+where
+    O: StableAddress,
+    H: Deref,
 {
     type Target = H::Target;
     fn deref(&self) -> &H::Target {
@@ -899,11 +934,16 @@ impl<O, H> Deref for OwningHandle<O, H>
 }
 
 unsafe impl<O, H> StableAddress for OwningHandle<O, H>
-    where O: StableAddress, H: StableAddress,
-{}
+where
+    O: StableAddress,
+    H: StableAddress,
+{
+}
 
 impl<O, H> DerefMut for OwningHandle<O, H>
-    where O: StableAddress, H: DerefMut,
+where
+    O: StableAddress,
+    H: DerefMut,
 {
     fn deref_mut(&mut self) -> &mut H::Target {
         self.handle.deref_mut()
@@ -931,7 +971,10 @@ pub trait ToHandleMut {
 }
 
 impl<O, H> OwningHandle<O, H>
-    where O: StableAddress, O::Target: ToHandle<Handle = H>, H: Deref,
+where
+    O: StableAddress,
+    O::Target: ToHandle<Handle = H>,
+    H: Deref,
 {
     /// Create a new `OwningHandle` for a type that implements `ToHandle`. For types
     /// that don't implement `ToHandle`, callers may invoke `new_with_fn`, which accepts
@@ -942,7 +985,10 @@ impl<O, H> OwningHandle<O, H>
 }
 
 impl<O, H> OwningHandle<O, H>
-    where O: StableAddress, O::Target: ToHandleMut<HandleMut = H>, H: DerefMut,
+where
+    O: StableAddress,
+    O::Target: ToHandleMut<HandleMut = H>,
+    H: DerefMut,
 {
     /// Create a new mutable `OwningHandle` for a type that implements `ToHandleMut`.
     pub fn new_mut(o: O) -> Self {
@@ -951,14 +997,17 @@ impl<O, H> OwningHandle<O, H>
 }
 
 impl<O, H> OwningHandle<O, H>
-    where O: StableAddress, H: Deref,
+where
+    O: StableAddress,
+    H: Deref,
 {
     /// Create a new OwningHandle. The provided callback will be invoked with
     /// a pointer to the object owned by `o`, and the returned value is stored
     /// as the object to which this `OwningHandle` will forward `Deref` and
     /// `DerefMut`.
     pub fn new_with_fn<F>(o: O, f: F) -> Self
-        where F: FnOnce(*const O::Target) -> H
+    where
+        F: FnOnce(*const O::Target) -> H,
     {
         let h: H;
         {
@@ -966,8 +1015,8 @@ impl<O, H> OwningHandle<O, H>
         }
 
         OwningHandle {
-          handle: h,
-          _owner: o,
+            handle: h,
+            _owner: o,
         }
     }
 
@@ -976,7 +1025,8 @@ impl<O, H> OwningHandle<O, H>
     /// as the object to which this `OwningHandle` will forward `Deref` and
     /// `DerefMut`.
     pub fn try_new<F, E>(o: O, f: F) -> Result<Self, E>
-        where F: FnOnce(*const O::Target) -> Result<H, E>
+    where
+        F: FnOnce(*const O::Target) -> Result<H, E>,
     {
         let h: H;
         {
@@ -984,8 +1034,8 @@ impl<O, H> OwningHandle<O, H>
         }
 
         Ok(OwningHandle {
-          handle: h,
-          _owner: o,
+            handle: h,
+            _owner: o,
         })
     }
 
@@ -1004,20 +1054,20 @@ impl<O, H> OwningHandle<O, H>
 // std traits
 /////////////////////////////////////////////////////////////////////////////
 
-use std::convert::From;
-use std::fmt::{self, Debug};
-use std::marker::{Send, Sync};
-use std::cmp::{Eq, PartialEq, Ord, PartialOrd, Ordering};
-use std::hash::{Hash, Hasher};
-use std::borrow::Borrow;
+use std::{
+    borrow::Borrow,
+    cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd},
+    convert::From,
+    fmt::{self, Debug},
+    hash::{Hash, Hasher},
+    marker::{Send, Sync},
+};
 
 impl<O, T: ?Sized> Deref for OwningRef<O, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
-        unsafe {
-            &*self.reference
-        }
+        unsafe { &*self.reference }
     }
 }
 
@@ -1025,17 +1075,13 @@ impl<O, T: ?Sized> Deref for OwningRefMut<O, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
-        unsafe {
-            &*self.reference
-        }
+        unsafe { &*self.reference }
     }
 }
 
 impl<O, T: ?Sized> DerefMut for OwningRefMut<O, T> {
     fn deref_mut(&mut self) -> &mut T {
-        unsafe {
-            &mut *self.reference
-        }
+        unsafe { &mut *self.reference }
     }
 }
 
@@ -1068,8 +1114,9 @@ impl<O, T: ?Sized> Borrow<T> for OwningRef<O, T> {
 }
 
 impl<O, T: ?Sized> From<O> for OwningRef<O, T>
-    where O: StableAddress,
-          O: Deref<Target = T>,
+where
+    O: StableAddress,
+    O: Deref<Target = T>,
 {
     fn from(owner: O) -> Self {
         OwningRef::new(owner)
@@ -1077,8 +1124,9 @@ impl<O, T: ?Sized> From<O> for OwningRef<O, T>
 }
 
 impl<O, T: ?Sized> From<O> for OwningRefMut<O, T>
-    where O: StableAddress,
-          O: DerefMut<Target = T>
+where
+    O: StableAddress,
+    O: DerefMut<Target = T>,
 {
     fn from(owner: O) -> Self {
         OwningRefMut::new(owner)
@@ -1086,8 +1134,9 @@ impl<O, T: ?Sized> From<O> for OwningRefMut<O, T>
 }
 
 impl<O, T: ?Sized> From<OwningRefMut<O, T>> for OwningRef<O, T>
-    where O: StableAddress,
-          O: DerefMut<Target = T>
+where
+    O: StableAddress,
+    O: DerefMut<Target = T>,
 {
     fn from(other: OwningRefMut<O, T>) -> Self {
         OwningRef {
@@ -1100,31 +1149,38 @@ impl<O, T: ?Sized> From<OwningRefMut<O, T>> for OwningRef<O, T>
 // ^ FIXME: Is a Into impl for calling into_owner() possible as well?
 
 impl<O, T: ?Sized> Debug for OwningRef<O, T>
-    where O: Debug,
-          T: Debug,
+where
+    O: Debug,
+    T: Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f,
-               "OwningRef {{ owner: {:?}, reference: {:?} }}",
-               self.as_owner(),
-               &**self)
+        write!(
+            f,
+            "OwningRef {{ owner: {:?}, reference: {:?} }}",
+            self.as_owner(),
+            &**self
+        )
     }
 }
 
 impl<O, T: ?Sized> Debug for OwningRefMut<O, T>
-    where O: Debug,
-          T: Debug,
+where
+    O: Debug,
+    T: Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f,
-               "OwningRefMut {{ owner: {:?}, reference: {:?} }}",
-               self.as_owner(),
-               &**self)
+        write!(
+            f,
+            "OwningRefMut {{ owner: {:?}, reference: {:?} }}",
+            self.as_owner(),
+            &**self
+        )
     }
 }
 
 impl<O, T: ?Sized> Clone for OwningRef<O, T>
-    where O: CloneStableAddress,
+where
+    O: CloneStableAddress,
 {
     fn clone(&self) -> Self {
         OwningRef {
@@ -1134,18 +1190,33 @@ impl<O, T: ?Sized> Clone for OwningRef<O, T>
     }
 }
 
-unsafe impl<O, T: ?Sized> CloneStableAddress for OwningRef<O, T>
-    where O: CloneStableAddress {}
+unsafe impl<O, T: ?Sized> CloneStableAddress for OwningRef<O, T> where O: CloneStableAddress {}
 
 unsafe impl<O, T: ?Sized> Send for OwningRef<O, T>
-    where O: Send, for<'a> (&'a T): Send {}
+where
+    O: Send,
+    for<'a> (&'a T): Send,
+{
+}
 unsafe impl<O, T: ?Sized> Sync for OwningRef<O, T>
-    where O: Sync, for<'a> (&'a T): Sync {}
+where
+    O: Sync,
+    for<'a> (&'a T): Sync,
+{
+}
 
 unsafe impl<O, T: ?Sized> Send for OwningRefMut<O, T>
-    where O: Send, for<'a> (&'a mut T): Send {}
+where
+    O: Send,
+    for<'a> (&'a mut T): Send,
+{
+}
 unsafe impl<O, T: ?Sized> Sync for OwningRefMut<O, T>
-    where O: Sync, for<'a> (&'a mut T): Sync {}
+where
+    O: Sync,
+    for<'a> (&'a mut T): Sync,
+{
+}
 
 impl Debug for dyn Erased {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
@@ -1153,53 +1224,77 @@ impl Debug for dyn Erased {
     }
 }
 
-impl<O, T: ?Sized> PartialEq for OwningRef<O, T> where T: PartialEq {
+impl<O, T: ?Sized> PartialEq for OwningRef<O, T>
+where
+    T: PartialEq,
+{
     fn eq(&self, other: &Self) -> bool {
         (&*self as &T).eq(&*other as &T)
-     }
+    }
 }
 
 impl<O, T: ?Sized> Eq for OwningRef<O, T> where T: Eq {}
 
-impl<O, T: ?Sized> PartialOrd for OwningRef<O, T> where T: PartialOrd {
+impl<O, T: ?Sized> PartialOrd for OwningRef<O, T>
+where
+    T: PartialOrd,
+{
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         (&*self as &T).partial_cmp(&*other as &T)
     }
 }
 
-impl<O, T: ?Sized> Ord for OwningRef<O, T> where T: Ord {
+impl<O, T: ?Sized> Ord for OwningRef<O, T>
+where
+    T: Ord,
+{
     fn cmp(&self, other: &Self) -> Ordering {
         (&*self as &T).cmp(&*other as &T)
     }
 }
 
-impl<O, T: ?Sized> Hash for OwningRef<O, T> where T: Hash {
+impl<O, T: ?Sized> Hash for OwningRef<O, T>
+where
+    T: Hash,
+{
     fn hash<H: Hasher>(&self, state: &mut H) {
         (&*self as &T).hash(state);
     }
 }
 
-impl<O, T: ?Sized> PartialEq for OwningRefMut<O, T> where T: PartialEq {
+impl<O, T: ?Sized> PartialEq for OwningRefMut<O, T>
+where
+    T: PartialEq,
+{
     fn eq(&self, other: &Self) -> bool {
         (&*self as &T).eq(&*other as &T)
-     }
+    }
 }
 
 impl<O, T: ?Sized> Eq for OwningRefMut<O, T> where T: Eq {}
 
-impl<O, T: ?Sized> PartialOrd for OwningRefMut<O, T> where T: PartialOrd {
+impl<O, T: ?Sized> PartialOrd for OwningRefMut<O, T>
+where
+    T: PartialOrd,
+{
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         (&*self as &T).partial_cmp(&*other as &T)
     }
 }
 
-impl<O, T: ?Sized> Ord for OwningRefMut<O, T> where T: Ord {
+impl<O, T: ?Sized> Ord for OwningRefMut<O, T>
+where
+    T: Ord,
+{
     fn cmp(&self, other: &Self) -> Ordering {
         (&*self as &T).cmp(&*other as &T)
     }
 }
 
-impl<O, T: ?Sized> Hash for OwningRefMut<O, T> where T: Hash {
+impl<O, T: ?Sized> Hash for OwningRefMut<O, T>
+where
+    T: Hash,
+{
     fn hash<H: Hasher>(&self, state: &mut H) {
         (&*self as &T).hash(state);
     }
@@ -1209,20 +1304,25 @@ impl<O, T: ?Sized> Hash for OwningRefMut<O, T> where T: Hash {
 // std types integration and convenience type defs
 /////////////////////////////////////////////////////////////////////////////
 
-use std::boxed::Box;
-use std::rc::Rc;
-use std::sync::Arc;
-use std::sync::{MutexGuard, RwLockReadGuard, RwLockWriteGuard};
-use std::cell::{Ref, RefCell, RefMut};
+use std::{
+    boxed::Box,
+    cell::{Ref, RefCell, RefMut},
+    rc::Rc,
+    sync::{Arc, MutexGuard, RwLockReadGuard, RwLockWriteGuard},
+};
 
 impl<T: 'static> ToHandle for RefCell<T> {
     type Handle = Ref<'static, T>;
-    unsafe fn to_handle(x: *const Self) -> Self::Handle { (*x).borrow() }
+    unsafe fn to_handle(x: *const Self) -> Self::Handle {
+        (*x).borrow()
+    }
 }
 
 impl<T: 'static> ToHandleMut for RefCell<T> {
     type HandleMut = RefMut<'static, T>;
-    unsafe fn to_handle_mut(x: *const Self) -> Self::HandleMut { (*x).borrow_mut() }
+    unsafe fn to_handle_mut(x: *const Self) -> Self::HandleMut {
+        (*x).borrow_mut()
+    }
 }
 
 // NB: Implementing ToHandle{,Mut} for Mutex and RwLock requires a decision
@@ -1298,13 +1398,13 @@ pub type ErasedBoxRefMut<U> = OwningRefMut<Box<dyn Erased>, U>;
 #[cfg(test)]
 mod tests {
     mod owning_ref {
-        use super::super::OwningRef;
-        use super::super::{RcRef, BoxRef, Erased, ErasedBoxRef};
-        use std::cmp::{PartialEq, Ord, PartialOrd, Ordering};
-        use std::hash::{Hash, Hasher};
-        use std::collections::hash_map::DefaultHasher;
-        use std::collections::HashMap;
-        use std::rc::Rc;
+        use super::super::{BoxRef, Erased, ErasedBoxRef, OwningRef, RcRef};
+        use std::{
+            cmp::{Ord, Ordering, PartialEq, PartialOrd},
+            collections::{hash_map::DefaultHasher, HashMap},
+            hash::{Hash, Hasher},
+            rc::Rc,
+        };
 
         #[derive(Debug, PartialEq)]
         struct Example(u32, String, [u8; 3]);
@@ -1387,16 +1487,17 @@ mod tests {
             let or: BoxRef<String> = Box::new(example().1).into();
             let or = or.map(|x| &x[..5]);
             let s = format!("{:?}", or);
-            assert_eq!(&s, "OwningRef { owner: \"hello world\", reference: \"hello\" }");
+            assert_eq!(
+                &s,
+                "OwningRef { owner: \"hello world\", reference: \"hello\" }"
+            );
         }
 
         #[test]
         fn erased_owner() {
-            let o1: BoxRef<Example, str> = BoxRef::new(Box::new(example()))
-                .map(|x| &x.1[..]);
+            let o1: BoxRef<Example, str> = BoxRef::new(Box::new(example())).map(|x| &x.1[..]);
 
-            let o2: BoxRef<String, str> = BoxRef::new(Box::new(example().1))
-                .map(|x| &x[..]);
+            let o2: BoxRef<String, str> = BoxRef::new(Box::new(example().1)).map(|x| &x[..]);
 
             let os: Vec<ErasedBoxRef<str>> = vec![o1.erase_owner(), o2.erase_owner()];
             assert!(os.iter().all(|e| &e[..] == "hello world"));
@@ -1423,10 +1524,13 @@ mod tests {
 
         #[test]
         fn raii_locks() {
-            use super::super::{RefRef, RefMutRef};
-            use std::cell::RefCell;
-            use super::super::{MutexGuardRef, RwLockReadGuardRef, RwLockWriteGuardRef};
-            use std::sync::{Mutex, RwLock};
+            use super::super::{
+                MutexGuardRef, RefMutRef, RefRef, RwLockReadGuardRef, RwLockWriteGuardRef,
+            };
+            use std::{
+                cell::RefCell,
+                sync::{Mutex, RwLock},
+            };
 
             {
                 let a = RefCell::new(1);
@@ -1518,7 +1622,7 @@ mod tests {
         #[test]
         fn borrow() {
             let mut hash = HashMap::new();
-            let     key  = RcRef::<String>::new(Rc::new("foo-bar".to_string())).map(|s| &s[..]);
+            let key = RcRef::<String>::new(Rc::new("foo-bar".to_string())).map(|s| &s[..]);
 
             hash.insert(key.clone().map(|s| &s[..3]), 42);
             hash.insert(key.clone().map(|s| &s[4..]), 23);
@@ -1529,13 +1633,12 @@ mod tests {
 
         #[test]
         fn total_erase() {
-            let a: OwningRef<Vec<u8>, [u8]>
-                = OwningRef::new(vec![]).map(|x| &x[..]);
-            let b: OwningRef<Box<[u8]>, [u8]>
-                = OwningRef::new(vec![].into_boxed_slice()).map(|x| &x[..]);
+            let a: OwningRef<Vec<u8>, [u8]> = OwningRef::new(vec![]).map(|x| &x[..]);
+            let b: OwningRef<Box<[u8]>, [u8]> =
+                OwningRef::new(vec![].into_boxed_slice()).map(|x| &x[..]);
 
-            let c: OwningRef<Rc<Vec<u8>>, [u8]> = unsafe {a.map_owner(Rc::new)};
-            let d: OwningRef<Rc<Box<[u8]>>, [u8]> = unsafe {b.map_owner(Rc::new)};
+            let c: OwningRef<Rc<Vec<u8>>, [u8]> = unsafe { a.map_owner(Rc::new) };
+            let d: OwningRef<Rc<Box<[u8]>>, [u8]> = unsafe { b.map_owner(Rc::new) };
 
             let e: OwningRef<Rc<dyn Erased>, [u8]> = c.erase_owner();
             let f: OwningRef<Rc<dyn Erased>, [u8]> = d.erase_owner();
@@ -1546,10 +1649,9 @@ mod tests {
 
         #[test]
         fn total_erase_box() {
-            let a: OwningRef<Vec<u8>, [u8]>
-                = OwningRef::new(vec![]).map(|x| &x[..]);
-            let b: OwningRef<Box<[u8]>, [u8]>
-                = OwningRef::new(vec![].into_boxed_slice()).map(|x| &x[..]);
+            let a: OwningRef<Vec<u8>, [u8]> = OwningRef::new(vec![]).map(|x| &x[..]);
+            let b: OwningRef<Box<[u8]>, [u8]> =
+                OwningRef::new(vec![].into_boxed_slice()).map(|x| &x[..]);
 
             let c: OwningRef<Box<Vec<u8>>, [u8]> = a.map_owner_box();
             let d: OwningRef<Box<Box<[u8]>>, [u8]> = b.map_owner_box();
@@ -1565,7 +1667,9 @@ mod tests {
             let x = Box::new(123_i32);
             let y: Box<dyn Any> = x;
 
-            OwningRef::new(y).try_map(|x| x.downcast_ref::<i32>().ok_or(())).unwrap();
+            OwningRef::new(y)
+                .try_map(|x| x.downcast_ref::<i32>().ok_or(()))
+                .unwrap();
         }
 
         #[test]
@@ -1575,7 +1679,9 @@ mod tests {
             let x = Box::new(123_u32);
             let y: Box<dyn Any> = x;
 
-            OwningRef::new(y).try_map(|x| x.downcast_ref::<i32>().ok_or(())).unwrap_err();
+            OwningRef::new(y)
+                .try_map(|x| x.downcast_ref::<i32>().ok_or(()))
+                .unwrap_err();
         }
 
         #[test]
@@ -1594,10 +1700,12 @@ mod tests {
             let owning_ref: BoxRef<Example> = Box::new(example()).into();
             let owning_ref = owning_ref.map(|owner| &owner.1);
 
-            owning_ref.try_map_with_owner(|owner, ref_field| {
-                assert_eq!(owner.1, *ref_field);
-                Ok(ref_field) as Result<_, ()>
-            }).unwrap();
+            owning_ref
+                .try_map_with_owner(|owner, ref_field| {
+                    assert_eq!(owner.1, *ref_field);
+                    Ok(ref_field) as Result<_, ()>
+                })
+                .unwrap();
         }
 
         #[test]
@@ -1605,27 +1713,31 @@ mod tests {
             let owning_ref: BoxRef<Example> = Box::new(example()).into();
             let owning_ref = owning_ref.map(|owner| &owner.1);
 
-            owning_ref.try_map_with_owner(|owner, ref_field| {
-                assert_eq!(owner.1, *ref_field);
-                Err(()) as Result<&(), _>
-            }).unwrap_err();
+            owning_ref
+                .try_map_with_owner(|owner, ref_field| {
+                    assert_eq!(owner.1, *ref_field);
+                    Err(()) as Result<&(), _>
+                })
+                .unwrap_err();
         }
     }
 
     mod owning_handle {
-        use super::super::OwningHandle;
-        use super::super::RcRef;
-        use std::rc::Rc;
-        use std::cell::RefCell;
-        use std::sync::Arc;
-        use std::sync::RwLock;
+        use super::super::{OwningHandle, RcRef};
+        use std::{
+            cell::RefCell,
+            rc::Rc,
+            sync::{Arc, RwLock},
+        };
 
         #[test]
         fn owning_handle() {
             use std::cell::RefCell;
             let cell = Rc::new(RefCell::new(2));
             let cell_ref = RcRef::new(cell);
-            let mut handle = OwningHandle::new_with_fn(cell_ref, |x| unsafe { x.as_ref() }.unwrap().borrow_mut());
+            let mut handle = OwningHandle::new_with_fn(cell_ref, |x| {
+                unsafe { x.as_ref() }.unwrap().borrow_mut()
+            });
             assert_eq!(*handle, 2);
             *handle = 3;
             assert_eq!(*handle, 3);
@@ -1637,10 +1749,9 @@ mod tests {
             let cell = Rc::new(RefCell::new(2));
             let cell_ref = RcRef::new(cell);
             let mut handle = OwningHandle::try_new::<_, ()>(cell_ref, |x| {
-                Ok(unsafe {
-                    x.as_ref()
-                }.unwrap().borrow_mut())
-            }).unwrap();
+                Ok(unsafe { x.as_ref() }.unwrap().borrow_mut())
+            })
+            .unwrap();
             assert_eq!(*handle, 2);
             *handle = 3;
             assert_eq!(*handle, 3);
@@ -1653,9 +1764,7 @@ mod tests {
             let cell_ref = RcRef::new(cell);
             let handle = OwningHandle::try_new::<_, ()>(cell_ref, |x| {
                 if false {
-                    return Ok(unsafe {
-                        x.as_ref()
-                    }.unwrap().borrow_mut())
+                    return Ok(unsafe { x.as_ref() }.unwrap().borrow_mut());
                 }
                 Err(())
             });
@@ -1664,14 +1773,20 @@ mod tests {
 
         #[test]
         fn nested() {
-            use std::cell::RefCell;
-            use std::sync::{Arc, RwLock};
+            use std::{
+                cell::RefCell,
+                sync::{Arc, RwLock},
+            };
 
             let result = {
                 let complex = Rc::new(RefCell::new(Arc::new(RwLock::new("someString"))));
                 let curr = RcRef::new(complex);
-                let curr = OwningHandle::new_with_fn(curr, |x| unsafe { x.as_ref() }.unwrap().borrow_mut());
-                let mut curr = OwningHandle::new_with_fn(curr, |x| unsafe { x.as_ref() }.unwrap().try_write().unwrap());
+                let curr = OwningHandle::new_with_fn(curr, |x| {
+                    unsafe { x.as_ref() }.unwrap().borrow_mut()
+                });
+                let mut curr = OwningHandle::new_with_fn(curr, |x| {
+                    unsafe { x.as_ref() }.unwrap().try_write().unwrap()
+                });
                 assert_eq!(*curr, "someString");
                 *curr = "someOtherString";
                 curr
@@ -1704,8 +1819,12 @@ mod tests {
             let result = {
                 let complex = Rc::new(RefCell::new(Arc::new(RwLock::new("someString"))));
                 let curr = RcRef::new(complex);
-                let curr = OwningHandle::new_with_fn(curr, |x| unsafe { x.as_ref() }.unwrap().borrow_mut());
-                let mut curr = OwningHandle::new_with_fn(curr, |x| unsafe { x.as_ref() }.unwrap().try_write().unwrap());
+                let curr = OwningHandle::new_with_fn(curr, |x| {
+                    unsafe { x.as_ref() }.unwrap().borrow_mut()
+                });
+                let mut curr = OwningHandle::new_with_fn(curr, |x| {
+                    unsafe { x.as_ref() }.unwrap().try_write().unwrap()
+                });
                 assert_eq!(*curr, "someString");
                 *curr = "someOtherString";
                 curr
@@ -1715,12 +1834,12 @@ mod tests {
     }
 
     mod owning_ref_mut {
-        use super::super::{OwningRefMut, BoxRefMut, Erased, ErasedBoxRefMut};
-        use super::super::BoxRef;
-        use std::cmp::{PartialEq, Ord, PartialOrd, Ordering};
-        use std::hash::{Hash, Hasher};
-        use std::collections::hash_map::DefaultHasher;
-        use std::collections::HashMap;
+        use super::super::{BoxRef, BoxRefMut, Erased, ErasedBoxRefMut, OwningRefMut};
+        use std::{
+            cmp::{Ord, Ordering, PartialEq, PartialOrd},
+            collections::{hash_map::DefaultHasher, HashMap},
+            hash::{Hash, Hasher},
+        };
 
         #[derive(Debug, PartialEq)]
         struct Example(u32, String, [u8; 3]);
@@ -1857,17 +1976,19 @@ mod tests {
             let or: BoxRefMut<String> = Box::new(example().1).into();
             let or = or.map_mut(|x| &mut x[..5]);
             let s = format!("{:?}", or);
-            assert_eq!(&s,
-                       "OwningRefMut { owner: \"hello world\", reference: \"hello\" }");
+            assert_eq!(
+                &s,
+                "OwningRefMut { owner: \"hello world\", reference: \"hello\" }"
+            );
         }
 
         #[test]
         fn erased_owner() {
-            let o1: BoxRefMut<Example, str> = BoxRefMut::new(Box::new(example()))
-                .map_mut(|x| &mut x.1[..]);
+            let o1: BoxRefMut<Example, str> =
+                BoxRefMut::new(Box::new(example())).map_mut(|x| &mut x.1[..]);
 
-            let o2: BoxRefMut<String, str> = BoxRefMut::new(Box::new(example().1))
-                .map_mut(|x| &mut x[..]);
+            let o2: BoxRefMut<String, str> =
+                BoxRefMut::new(Box::new(example().1)).map_mut(|x| &mut x[..]);
 
             let os: Vec<ErasedBoxRefMut<str>> = vec![o1.erase_owner(), o2.erase_owner()];
             assert!(os.iter().all(|e| &e[..] == "hello world"));
@@ -1894,10 +2015,11 @@ mod tests {
 
         #[test]
         fn raii_locks() {
-            use super::super::RefMutRefMut;
-            use std::cell::RefCell;
-            use super::super::{MutexGuardRefMut, RwLockWriteGuardRefMut};
-            use std::sync::{Mutex, RwLock};
+            use super::super::{MutexGuardRefMut, RefMutRefMut, RwLockWriteGuardRefMut};
+            use std::{
+                cell::RefCell,
+                sync::{Mutex, RwLock},
+            };
 
             {
                 let a = RefCell::new(1);
@@ -1969,8 +2091,8 @@ mod tests {
         #[test]
         fn borrow() {
             let mut hash = HashMap::new();
-            let     key1 = BoxRefMut::<String>::new(Box::new("foo".to_string())).map(|s| &s[..]);
-            let     key2 = BoxRefMut::<String>::new(Box::new("bar".to_string())).map(|s| &s[..]);
+            let key1 = BoxRefMut::<String>::new(Box::new("foo".to_string())).map(|s| &s[..]);
+            let key2 = BoxRefMut::<String>::new(Box::new("bar".to_string())).map(|s| &s[..]);
 
             hash.insert(key1, 42);
             hash.insert(key2, 23);
@@ -1981,13 +2103,12 @@ mod tests {
 
         #[test]
         fn total_erase() {
-            let a: OwningRefMut<Vec<u8>, [u8]>
-                = OwningRefMut::new(vec![]).map_mut(|x| &mut x[..]);
-            let b: OwningRefMut<Box<[u8]>, [u8]>
-                = OwningRefMut::new(vec![].into_boxed_slice()).map_mut(|x| &mut x[..]);
+            let a: OwningRefMut<Vec<u8>, [u8]> = OwningRefMut::new(vec![]).map_mut(|x| &mut x[..]);
+            let b: OwningRefMut<Box<[u8]>, [u8]> =
+                OwningRefMut::new(vec![].into_boxed_slice()).map_mut(|x| &mut x[..]);
 
-            let c: OwningRefMut<Box<Vec<u8>>, [u8]> = unsafe {a.map_owner(Box::new)};
-            let d: OwningRefMut<Box<Box<[u8]>>, [u8]> = unsafe {b.map_owner(Box::new)};
+            let c: OwningRefMut<Box<Vec<u8>>, [u8]> = unsafe { a.map_owner(Box::new) };
+            let d: OwningRefMut<Box<Box<[u8]>>, [u8]> = unsafe { b.map_owner(Box::new) };
 
             let _e: OwningRefMut<Box<dyn Erased>, [u8]> = c.erase_owner();
             let _f: OwningRefMut<Box<dyn Erased>, [u8]> = d.erase_owner();
@@ -1995,10 +2116,9 @@ mod tests {
 
         #[test]
         fn total_erase_box() {
-            let a: OwningRefMut<Vec<u8>, [u8]>
-                = OwningRefMut::new(vec![]).map_mut(|x| &mut x[..]);
-            let b: OwningRefMut<Box<[u8]>, [u8]>
-                = OwningRefMut::new(vec![].into_boxed_slice()).map_mut(|x| &mut x[..]);
+            let a: OwningRefMut<Vec<u8>, [u8]> = OwningRefMut::new(vec![]).map_mut(|x| &mut x[..]);
+            let b: OwningRefMut<Box<[u8]>, [u8]> =
+                OwningRefMut::new(vec![].into_boxed_slice()).map_mut(|x| &mut x[..]);
 
             let c: OwningRefMut<Box<Vec<u8>>, [u8]> = a.map_owner_box();
             let d: OwningRefMut<Box<Box<[u8]>>, [u8]> = b.map_owner_box();
@@ -2014,7 +2134,9 @@ mod tests {
             let x = Box::new(123_i32);
             let y: Box<dyn Any> = x;
 
-            OwningRefMut::new(y).try_map_mut(|x| x.downcast_mut::<i32>().ok_or(())).unwrap();
+            OwningRefMut::new(y)
+                .try_map_mut(|x| x.downcast_mut::<i32>().ok_or(()))
+                .unwrap();
         }
 
         #[test]
@@ -2024,7 +2146,9 @@ mod tests {
             let x = Box::new(123_u32);
             let y: Box<dyn Any> = x;
 
-            OwningRefMut::new(y).try_map_mut(|x| x.downcast_mut::<i32>().ok_or(())).unwrap_err();
+            OwningRefMut::new(y)
+                .try_map_mut(|x| x.downcast_mut::<i32>().ok_or(()))
+                .unwrap_err();
         }
 
         #[test]
@@ -2034,7 +2158,9 @@ mod tests {
             let x = Box::new(123_i32);
             let y: Box<dyn Any> = x;
 
-            OwningRefMut::new(y).try_map(|x| x.downcast_ref::<i32>().ok_or(())).unwrap();
+            OwningRefMut::new(y)
+                .try_map(|x| x.downcast_ref::<i32>().ok_or(()))
+                .unwrap();
         }
 
         #[test]
@@ -2044,7 +2170,9 @@ mod tests {
             let x = Box::new(123_u32);
             let y: Box<dyn Any> = x;
 
-            OwningRefMut::new(y).try_map(|x| x.downcast_ref::<i32>().ok_or(())).unwrap_err();
+            OwningRefMut::new(y)
+                .try_map(|x| x.downcast_ref::<i32>().ok_or(()))
+                .unwrap_err();
         }
 
         #[test]


### PR DESCRIPTION
This PR is based on #73. It adds a `rustfmt.toml` and format code with `rustfmt`.