### PR TITLE
Fix #77

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -793,6 +793,16 @@ impl<'t, O, T: ?Sized> OwningRefMut<'t, O, T> {
         }
     }
 
+    /// A reference to the underlying owner.
+    pub unsafe fn as_owner(&self) -> &O {
+        &self.owner
+    }
+
+    /// A mutable reference to the underlying owner.
+    pub unsafe fn as_owner_mut(&mut self) -> &mut O {
+        &mut self.owner
+    }
+
     /// Discards the reference and retrieves the owner.
     pub fn into_owner(self) -> O {
         self.owner
@@ -1783,7 +1793,7 @@ mod tests {
             let or: BoxRefMut<String> = Box::new(example().1).into();
             let or = or.map_mut(|x| &mut x[..5]);
             assert_eq!(&*or, "hello");
-            assert_eq!(&**or.as_owner(), "hello world");
+            assert_eq!(&** unsafe { or.as_owner() }, "hello world");
         }
 
         #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -793,18 +793,6 @@ impl<'t, O, T: ?Sized> OwningRefMut<'t, O, T> {
         }
     }
 
-    // TODO: wrap_owner
-
-    /// A reference to the underlying owner.
-    pub fn as_owner(&self) -> &O {
-        &self.owner
-    }
-
-    /// A mutable reference to the underlying owner.
-    pub fn as_owner_mut(&mut self) -> &mut O {
-        &mut self.owner
-    }
-
     /// Discards the reference and retrieves the owner.
     pub fn into_owner(self) -> O {
         self.owner

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,7 +609,7 @@ impl<'t, O, T: ?Sized> OwningRefMut<'t, O, T> {
     ///
     ///     // create a owning reference that points at the
     ///     // third element of the array.
-    ///     let owning_ref = owning_ref_mut.map(|array| &array[2]);
+    ///     let owning_ref = unsafe { owning_ref_mut.map(|array| &array[2]) };
     ///     assert_eq!(*owning_ref, 3);
     /// }
     /// ```
@@ -671,9 +671,11 @@ impl<'t, O, T: ?Sized> OwningRefMut<'t, O, T> {
     ///
     ///     // create a owning reference that points at the
     ///     // third element of the array.
-    ///     let owning_ref = owning_ref_mut.try_map(|array| {
-    ///         if array[2] == 3 { Ok(&array[2]) } else { Err(()) }
-    ///     });
+    ///     let owning_ref = unsafe {
+    ///         owning_ref_mut.try_map(|array| {
+    ///             if array[2] == 3 { Ok(&array[2]) } else { Err(()) }
+    ///         })
+    ///     };
     ///     assert_eq!(*owning_ref.unwrap(), 3);
     /// }
     /// ```
@@ -1709,18 +1711,18 @@ mod tests {
         #[test]
         fn map_offset_ref() {
             let or: BoxRefMut<Example> = Box::new(example()).into();
-            let or: BoxRef<_, u32> = unsafe { or.map(|x| &mut x.0) };
+            let or: BoxRefMut<_, u32> = or.map_mut(|x| &mut x.0);
             assert_eq!(&*or, &42);
 
             let or: BoxRefMut<Example> = Box::new(example()).into();
-            let or: BoxRef<_, u8> = unsafe { or.map(|x| &mut x.2[1]) };
+            let or: BoxRefMut<_, u8> = or.map_mut(|x| &mut x.2[1]);
             assert_eq!(&*or, &2);
         }
 
         #[test]
         fn map_heap_ref() {
             let or: BoxRefMut<Example> = Box::new(example()).into();
-            let or: BoxRef<_, str> = unsafe { or.map(|x| &mut x.1[..5]) };
+            let or: BoxRefMut<_, str> = or.map_mut(|x| &mut x.1[..5]);
             assert_eq!(&*or, "hello");
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1060,8 +1060,7 @@ impl<'t, O, T: ?Sized> Debug for OwningRefMut<'t, O, T>
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f,
-               "OwningRefMut {{ owner: {:?}, reference: {:?} }}",
-               self.as_owner(),
+               "OwningRefMut {{ owner: _, reference: {:?} }}",
                &**self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,6 +368,18 @@ impl<'t, O, T: ?Sized> OwningRef<'t, O, T> {
         }
     }
 
+    /// Old version of `map_with_owner`, now recognized as unsafe.
+    pub unsafe fn map_with_owner_direct<F, U: ?Sized>(self, f: F) -> OwningRef<'t, O, U>
+        where O: StableAddress,
+              F: for<'a> FnOnce(&'a O, &'a T) -> &'a U
+    {
+        OwningRef {
+            reference: f(&self.owner, &self),
+            owner: self.owner,
+            marker: PhantomData,
+        }
+    }
+
     /// Converts `self` into a new owning reference that points at something reachable
     /// from the previous one or from the owner itself.
     ///
@@ -391,8 +403,8 @@ impl<'t, O, T: ?Sized> OwningRef<'t, O, T> {
     /// }
     /// ```
     pub fn map_with_owner<F, U: ?Sized>(self, f: F) -> OwningRef<'t, O, U>
-        where O: StableAddress,
-              F: for<'a> FnOnce(&'a O, &'a T) -> &'a U
+        where O: StableAddress + Deref,
+              F: for<'a> FnOnce(&'a O::Target, &'a T) -> &'a U
     {
         OwningRef {
             reference: f(&self.owner, &self),
@@ -434,6 +446,18 @@ impl<'t, O, T: ?Sized> OwningRef<'t, O, T> {
         })
     }
 
+    /// Old version of `try_map_with_owner`, now recognized as unsafe.
+    pub unsafe fn try_map_with_owner_direct<F, U: ?Sized, E>(self, f: F) -> Result<OwningRef<'t, O, U>, E>
+        where O: StableAddress,
+              F: for<'a> FnOnce(&'a O, &'a T) -> Result<&'a U, E>
+    {
+        Ok(OwningRef {
+            reference: f(&self.owner, &self)?,
+            owner: self.owner,
+            marker: PhantomData,
+        })
+    }
+
     /// Tries to convert `self` into a new owning reference that points
     /// at something reachable from the previous one.
     ///
@@ -458,8 +482,8 @@ impl<'t, O, T: ?Sized> OwningRef<'t, O, T> {
     /// }
     /// ```
     pub fn try_map_with_owner<F, U: ?Sized, E>(self, f: F) -> Result<OwningRef<'t, O, U>, E>
-        where O: StableAddress,
-              F: for<'a> FnOnce(&'a O, &'a T) -> Result<&'a U, E>
+        where O: StableAddress + Deref,
+              F: for<'a> FnOnce(&'a O::Target, &'a T) -> Result<&'a U, E>
     {
         Ok(OwningRef {
             reference: f(&self.owner, &self)?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -961,7 +961,7 @@ use std::fmt::{self, Debug};
 use std::marker::{Send, Sync};
 use std::cmp::{Eq, PartialEq, Ord, PartialOrd, Ordering};
 use std::hash::{Hash, Hasher};
-use std::borrow::Borrow;
+use std::borrow::{Borrow, BorrowMut};
 
 impl<'t, O, T: ?Sized> Deref for OwningRef<'t, O, T> {
     type Target = T;
@@ -1016,6 +1016,18 @@ impl<'t, O, T: ?Sized> AsMut<T> for OwningRefMut<'t, O, T> {
 impl<'t, O, T: ?Sized> Borrow<T> for OwningRef<'t, O, T> {
     fn borrow(&self) -> &T {
         &*self
+    }
+}
+
+impl<'t, O, T: ?Sized> Borrow<T> for OwningRefMut<'t, O, T> {
+    fn borrow(&self) -> &T {
+        &*self
+    }
+}
+
+impl<'t, O, T: ?Sized> BorrowMut<T> for OwningRefMut<'t, O, T> {
+    fn borrow_mut(&mut self) -> &mut T {
+        &mut *self
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,6 +369,7 @@ impl<'t, O, T: ?Sized> OwningRef<'t, O, T> {
     }
 
     /// Old version of `map_with_owner`, now recognized as unsafe.
+    #[deprecated(since = "0.5.0", note = "unsafe function: please use map_with_owner instead")]
     pub unsafe fn map_with_owner_direct<F, U: ?Sized>(self, f: F) -> OwningRef<'t, O, U>
         where O: StableAddress,
               F: for<'a> FnOnce(&'a O, &'a T) -> &'a U
@@ -446,7 +447,18 @@ impl<'t, O, T: ?Sized> OwningRef<'t, O, T> {
         })
     }
 
+    // fn check() {
+    //     let box_i = Box::new(32);
+    //     let ref_i = &*box_i;
+    //     let ow_ref = OwningRef::new(Box::new(9));
+    //     let ow_ref : OwningRef<'static, _, _> = unsafe { ow_ref.map_owner(|_| ref_i) };
+    //     println!("{:?}", ow_ref);
+    //     drop(box_i);
+    // }
+    
+
     /// Old version of `try_map_with_owner`, now recognized as unsafe.
+    #[deprecated(since = "0.5.0", note = "unsafe function: please use try_map_with_owner instead")]
     pub unsafe fn try_map_with_owner_direct<F, U: ?Sized, E>(self, f: F) -> Result<OwningRef<'t, O, U>, E>
         where O: StableAddress,
               F: for<'a> FnOnce(&'a O, &'a T) -> Result<&'a U, E>
@@ -637,6 +649,8 @@ impl<'t, O, T: ?Sized> OwningRefMut<'t, O, T> {
     ///     assert_eq!(*owning_ref, 3);
     /// }
     /// ```
+    /// 
+    #[deprecated(since = "0.5.0", note = "unsafe function. can create aliased references")]
     pub unsafe fn map<F, U: ?Sized>(mut self, f: F) -> OwningRef<'t, O, U>
         where O: StableAddress,
               F: FnOnce(&mut T) -> &U
@@ -703,6 +717,8 @@ impl<'t, O, T: ?Sized> OwningRefMut<'t, O, T> {
     ///     assert_eq!(*owning_ref.unwrap(), 3);
     /// }
     /// ```
+    /// 
+    #[deprecated(since = "0.5.0", note = "unsafe function. can create aliased references")]
     pub unsafe fn try_map<F, U: ?Sized, E>(mut self, f: F) -> Result<OwningRef<'t, O, U>, E>
         where O: StableAddress,
               F: FnOnce(&mut T) -> Result<&U, E>
@@ -820,11 +836,13 @@ impl<'t, O, T: ?Sized> OwningRefMut<'t, O, T> {
     }
 
     /// A reference to the underlying owner.
+    #[deprecated(since = "0.5.0", note = "unsafe function. can create aliased references")]
     pub unsafe fn as_owner(&self) -> &O {
         &self.owner
     }
 
     /// A mutable reference to the underlying owner.
+    #[deprecated(since = "0.5.0", note = "unsafe function. can create aliased references")]
     pub unsafe fn as_owner_mut(&mut self) -> &mut O {
         &mut self.owner
     }


### PR DESCRIPTION
This is my fork that fixes #77 . I based it on the existing work in #72  .

Some things I'm not sure of:
* Which option for the semantics of `OwningRef` is appropriate? For now I chose to implement "allow `OwningRef::as_owner` and similar methods, but disallow convertion from `OwningRefMut` to `OwningRef`". But perhaps the other option is better.
* Should unsafe functions be kept as unsafe (and deprecated) methods for backwards compatibility?
* How exactly should I change the documentation of these functions?

For now the functions that became unsafe keep their documentation, except it has `unsafe` in the doc-tests so they wouldn't fail. `map_with_owner` has changed to be safe, and a new unsafe deprecated function called `map_with_owner_direct` equivalent to the old one was added, for backwards compatibility. However on second thought creating a new deprecated function doesn't seem like the best decision, so I would like to hear what would be preferred.

And of course, thank you for your time maintaining this library!