### PR TITLE
Add OwningHandle::new_with_async_fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "owning_ref"
 version = "0.4.1"
+edition = "2018"
 authors = ["Marvin Löbel <loebel.marvin@gmail.com>"]
 license = "MIT"
 
@@ -13,3 +14,6 @@ keywords = ["reference", "sibling", "field", "owning"]
 
 [dependencies]
 stable_deref_trait = "1.0.0"
+
+[dev-dependencies]
+tokio = {version = "^1.17.0", features = ["rt", "macros"] }


### PR DESCRIPTION
Adds the capability to use `async` functions in `OwningHandle::new_with_fn`.